### PR TITLE
Replace colons in plugin filename with dashes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,9 +51,15 @@ jobs:
       - name: Build plugin
         run: |
           make build ARCH=${{ matrix.arch }} KRAKEND_BUILDER_IMAGE=${{ matrix.krakend-builder-image }} RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+      
+      - name: Sanitise KrakenD builder image name
+        run: |
+          KRAKEND_BUILDER_IMAGE=${{ matrix.krakend-builder-image }}
+          KRAKEND_BUILDER_IMAGE=${KRAKEND_BUILDER_IMAGE/:/-}
+          echo KRAKEND_BUILDER_IMAGE=${KRAKEND_BUILDER_IMAGE} >> $GITHUB_ENV
 
       - name: Upload plugin .so file as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: firetail-krakend-plugin-${{ matrix.arch }}-${{ matrix.krakend-builder-image }}-${{ env.RELEASE_VERSION }}
-          path: firetail-krakend-plugin-${{ matrix.arch }}-${{ matrix.krakend-builder-image }}-${{ env.RELEASE_VERSION }}.so
+          name: firetail-krakend-plugin-${{ matrix.arch }}-${{ env.KRAKEND_BUILDER_IMAGE }}-${{ env.RELEASE_VERSION }}
+          path: firetail-krakend-plugin-${{ matrix.arch }}-${{ env.KRAKEND_BUILDER_IMAGE }}-${{ env.RELEASE_VERSION }}.so

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,11 +32,17 @@ jobs:
         run: |
           make build ARCH=${{ matrix.arch }} KRAKEND_BUILDER_IMAGE=${{ matrix.krakend-builder-image }} RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
+      - name: Sanitise KrakenD builder image name
+        run: |
+          KRAKEND_BUILDER_IMAGE=${{ matrix.krakend-builder-image }}
+          KRAKEND_BUILDER_IMAGE=${KRAKEND_BUILDER_IMAGE/:/-}
+          echo KRAKEND_BUILDER_IMAGE=${KRAKEND_BUILDER_IMAGE} >> $GITHUB_ENV
+
       - name: Upload plugin .so file as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: firetail-krakend-plugin-${{ matrix.arch }}-${{ matrix.krakend-builder-image }}-${{ env.RELEASE_VERSION }}
-          path: firetail-krakend-plugin-${{ matrix.arch }}-${{ matrix.krakend-builder-image }}-${{ env.RELEASE_VERSION }}.so
+          name: firetail-krakend-plugin-${{ matrix.arch }}-${{ env.KRAKEND_BUILDER_IMAGE }}-${{ env.RELEASE_VERSION }}
+          path: firetail-krakend-plugin-${{ matrix.arch }}-${{ env.KRAKEND_BUILDER_IMAGE }}-${{ env.RELEASE_VERSION }}.so
 
       - name: Get release
         id: get_release
@@ -50,6 +56,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_name: firetail-krakend-plugin-${{ matrix.arch }}-${{ matrix.krakend-builder-image }}-${{ env.RELEASE_VERSION }}.so
-          asset_path: firetail-krakend-plugin-${{ matrix.arch }}-${{ matrix.krakend-builder-image }}-${{ env.RELEASE_VERSION }}.so
+          asset_name: firetail-krakend-plugin-${{ matrix.arch }}-${{ env.KRAKEND_BUILDER_IMAGE }}-${{ env.RELEASE_VERSION }}.so
+          asset_path: firetail-krakend-plugin-${{ matrix.arch }}-${{ env.KRAKEND_BUILDER_IMAGE }}-${{ env.RELEASE_VERSION }}.so
           asset_content_type: application/x-sharedlib

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ RELEASE_VERSION := latest
 
 .PHONY: build
 build:
-	docker run --platform linux/${ARCH} -v "${PWD}:/app" -w /app krakend/${KRAKEND_BUILDER_IMAGE} go build -buildmode=plugin -o firetail-krakend-plugin-${ARCH}-${KRAKEND_BUILDER_IMAGE}-${RELEASE_VERSION}.so .
+	docker run --platform linux/${ARCH} -v "${PWD}:/app" -w /app krakend/${KRAKEND_BUILDER_IMAGE} go build -buildmode=plugin -o firetail-krakend-plugin-${ARCH}-$(subst :,-,${KRAKEND_BUILDER_IMAGE})-${RELEASE_VERSION}.so .


### PR DESCRIPTION
actions/upload-artifact@v3 doesn't support having `:` in artifact filenames (see: https://github.com/actions/upload-artifact/issues/35)